### PR TITLE
chore: update duplicate check style

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yml
@@ -15,13 +15,14 @@ body:
       placeholder: Bug description
     validations:
       required: true
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: Have you searched existing issues?  🔎
       description: Please search to see if an issue already exists for the issue you encountered.
       options:
-        - label: I have searched and found no existing issues
-          required: true
+        - no check
+        - I have searched and found no existing issues
+      default: 0
   - type: textarea
     id: reproduction
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,13 +8,14 @@ body:
       value: |
         First, check out our [Collaboration Guide](https://zncdata.dev/docs/developer-manual/collaboration)
         Please provide a searchable summary of the issue in the title above ⬆️.
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: Duplicates
       description: Please [search the history](https://github.com/zncdatadev/trino-operator/issues) to see if an issue already exists for the same problem.
       options:
-        - label: I have searched the existing issues
-          required: true
+        - no check
+        - I have searched the existing issues
+      default: 0
   - type: textarea
     attributes:
       label: Summary 💡


### PR DESCRIPTION
use dropdown style to replace the checkbox style, thus the duplicate check is no more treated as a tasklist item

close #95 