### PR TITLE
refactor(api): rename 'CommandArgsOverrides' to 'CliOverrides'

### DIFF
--- a/api/v1alpha1/trino_types.go
+++ b/api/v1alpha1/trino_types.go
@@ -145,7 +145,7 @@ type BaseRoleSpec struct {
 	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
-	CommandArgsOverrides []string `json:"commandArgsOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	EnvOverrides map[string]string `json:"envOverrides,omitempty"`
@@ -185,7 +185,7 @@ type RoleGroupSpec struct {
 	Config *ConfigSpec `json:"config,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	CommandArgsOverrides []string `json:"commandArgsOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	ConfigOverrides *ConfigOverridesSpec `json:"configOverrides,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -56,8 +56,8 @@ func (in *BaseRoleSpec) DeepCopyInto(out *BaseRoleSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.CommandArgsOverrides != nil {
-		in, out := &in.CommandArgsOverrides, &out.CommandArgsOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -541,8 +541,8 @@ func (in *RoleGroupSpec) DeepCopyInto(out *RoleGroupSpec) {
 		*out = new(ConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CommandArgsOverrides != nil {
-		in, out := &in.CommandArgsOverrides, &out.CommandArgsOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/trino.zncdata.dev_trinoclusters.yaml
+++ b/config/crd/bases/trino.zncdata.dev_trinoclusters.yaml
@@ -130,7 +130,7 @@ spec:
                 type: object
               coordinators:
                 properties:
-                  commandArgsOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -1259,7 +1259,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandArgsOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array
@@ -2416,7 +2416,7 @@ spec:
                 type: object
               workers:
                 properties:
-                  commandArgsOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -3545,7 +3545,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandArgsOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array

--- a/internal/controller/coordinator/role.go
+++ b/internal/controller/coordinator/role.go
@@ -78,7 +78,7 @@ func (r *Reconciler) registerResourceWithRoleGroup(_ context.Context, info recon
 			Labels:        info.GetLabels(),
 			Annotations:   info.GetAnnotations(),
 		},
-		CommandOverrides: spec.CommandArgsOverrides,
+		CommandOverrides: spec.CliOverrides,
 		EnvOverrides:     spec.EnvOverrides,
 	}
 

--- a/internal/controller/worker/role.go
+++ b/internal/controller/worker/role.go
@@ -78,7 +78,7 @@ func (r *Reconciler) registerResourceWithRoleGroup(_ context.Context, info recon
 			Labels:        info.GetLabels(),
 			Annotations:   info.GetAnnotations(),
 		},
-		CommandOverrides: spec.CommandArgsOverrides,
+		CommandOverrides: spec.CliOverrides,
 		EnvOverrides:     spec.EnvOverrides,
 	}
 


### PR DESCRIPTION
References https://github.com/zncdatadev/trino-operator/issues/154
