### PR TITLE
fix: add --config to chainsaw test in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 
   release-chart:


### PR DESCRIPTION
## Problem

The chart e2e step in `release.yml` was missing `--config`, causing chainsaw to use **default timeouts (AssertTimeout 30s)** instead of the configured values in `.chainsaw.yaml` (assert: 120s). Heavy services need >30s to start, causing **false timeout failures** in the Release workflow while standalone Chainsaw Test jobs pass fine.

This was discovered during the hive-operator 0.4.0-dev release: <https://github.com/zncdatadev/hive-operator/pull/327>

## Fix

Align chainsaw command in release.yml with chart-lint-test.yml to always use `--config ./test/e2e/.chainsaw.yaml`.

## Verified locally on hive-operator

- Hive Metastore starts in ~45-77s in KinD cluster (exceeds default 30s timeout)
- `.chainsaw.yaml` configures `assert: 120s`, `error: 10s`