### PR TITLE
fix: use CR spec productVersion in GetImage instead of hardcoded default

### DIFF
--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -37,22 +37,21 @@ func NewClusterReconciler(
 }
 
 func (r *Reconciler) GetImage() *util.Image {
-	image := util.NewImage(
+	productVersion := trinov1alpha1.DefaultProductVersion
+	if r.Spec.Image.ProductVersion != "" {
+		productVersion = r.Spec.Image.ProductVersion
+	}
+
+	return util.NewImage(
 		trinov1alpha1.DefaultProductName,
 		version.BuildVersion,
-		trinov1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo
 			options.PullPolicy = r.Spec.Image.PullPolicy
 		},
 	)
-
-	if r.Spec.Image.KubedoopVersion != "" {
-		image.KubedoopVersion = r.Spec.Image.KubedoopVersion
-	}
-
-	return image
 }
 
 func (r *Reconciler) getCoordinatorSvcFqdn() string {


### PR DESCRIPTION
## Problem

\`GetImage()\` always used \`DefaultProductVersion = "451"\` as the product version, ignoring the \`productVersion\` field in the TrinoCluster CR spec. This is the same issue as zookeeper-operator #348.

## Changes

- Prioritize \`r.Spec.Image.ProductVersion\` from CR spec when set
- Fall back to \`DefaultProductVersion\` only when CR spec does not specify it
- Remove post-construction mutation of \`KubedoopVersion\` (not related to this bug but cleanup)