### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -30,7 +30,7 @@ jobs:
           # Check if the CRDs are in sync with the manifests
           if ! git diff --exit-code; then
             echo "CRDs are not in sync with the manifests."
-            echo "Please run 'make manifest' to update the CRDs."
+            echo "Please run 'make manifests' to update the CRDs."
             exit 1
           fi
 

--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -30,7 +30,7 @@ jobs:
           # Check if the CRDs are in sync with the manifests
           if ! git diff --exit-code; then
             echo "CRDs are not in sync with the manifests."
-            echo "Please run 'make manifests' to update the CRDs."
+            echo "Please run 'make manifest' to update the CRDs."
             exit 1
           fi
 
@@ -49,7 +49,7 @@ jobs:
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -86,49 +86,38 @@ jobs:
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/trino-operator:$VERSION
-
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/trino-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-            hive-operator
-          )
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace trino-operator --wait trino-operator ./target/charts/trino-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -209,8 +209,16 @@ jobs:
         id: commit-range
         run: |
           # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
@@ -282,54 +290,45 @@ jobs:
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/trino-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/trino-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-            hive-operator
-          )
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install packaged operator chart
-          helm install --create-namespace --namespace trino-operator --wait trino-operator ./target/charts/trino-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e
 
 
   release-chart:
@@ -338,7 +337,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -283,14 +283,6 @@ helm-chart-package: ## Package helm chart for the operator.
 	rm -rf target/charts/*.tgz
 	"$(HELM)" package deploy/helm/$(PROJECT_NAME) --version $(VERSION) --app-version $(VERSION) --destination target/charts
 
-.PHONY: chart-e2e
-chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
-	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
-	"$(HELM)" upgrade --install --create-namespace --namespace trino-operator \
-		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
-		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
-
 .PHONY: helm-chart-publish ## Publish helm chart for the operator.
 helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 	"$(HELM)" push target/charts/$(PROJECT_NAME)-$(VERSION).tgz $(OCI_REGISTRY)
@@ -346,6 +338,14 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
+
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace trino-operator \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 .PHONY: chainsaw-e2e
 chainsaw-e2e: ## Run the chainsaw e2e tests

--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,14 @@ helm-chart-package: ## Package helm chart for the operator.
 	rm -rf target/charts/*.tgz
 	"$(HELM)" package deploy/helm/$(PROJECT_NAME) --version $(VERSION) --app-version $(VERSION) --destination target/charts
 
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace trino-operator \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+
 .PHONY: helm-chart-publish ## Publish helm chart for the operator.
 helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 	"$(HELM)" push target/charts/$(PROJECT_NAME)-$(VERSION).tgz $(OCI_REGISTRY)


### PR DESCRIPTION
## Changes

Aligned with commons-operator / listener-operator / secret-operator baseline.

### chart-lint-test.yml + release.yml
- Split \`lint-test\` / \`chart-lint-test\` into two independent jobs:
  - **chart-lint-helm**: ct lint + ct install (with independent Setup Go + Build image steps)
  - **chart-e2e**: \`make chart-e2e\` (chainsaw e2e via Helm deployment)
- Add **-dev tag filtering** in release.yml \`Get commit range\` step (exclude \`-dev\` pre-release tags)
- Fix **kind cluster name**: removed \`cluster_name: kind\` override, both workflows now use default \`chart-testing\`
- Remove \`id: ct-test\` and conditional tracking from chart-testing install step
- Update \`release-chart.needs\` to \`[chart-linter-artifacthub, chart-lint-helm, chart-e2e]\`

### Makefile
- Add \`chart-e2e\` target: depends on \`setup-chainsaw-cluster chainsaw docker-build helm-chart-package\`
  - kind load docker-image + helm upgrade --install + chainsaw test

### Reference
- commons-operator #285
- listener-operator #325
- secret-operator #343