### PR TITLE
fix(e2e): replace bash-specific [[ with POSIX [ for /bin/sh compatibility

### DIFF
--- a/test/e2e/smoke/observability/chainsaw-test.yaml
+++ b/test/e2e/smoke/observability/chainsaw-test.yaml
@@ -60,7 +60,7 @@ spec:
 
               # Test metrics endpoint accessibility
               HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/metrics)
-              if [[ "$HTTP_CODE" != "200" ]]; then
+              if [ "$HTTP_CODE" != "200" ]; then
                 echo "ERROR: Failed to access metrics endpoint, HTTP code: $HTTP_CODE"
                 kill $PF_PID 2>/dev/null || true
                 exit 1

--- a/test/e2e/smoke/override-pdb-hive-s3/trino-access.yaml
+++ b/test/e2e/smoke/override-pdb-hive-s3/trino-access.yaml
@@ -80,7 +80,7 @@ spec:
     - |
       set -ex
       # Check for the presence of both flag files to confirm success
-      if [[ -f /data/active && -f /data/s3 ]]; then
+      if [ -f /data/active ] && [ -f /data/s3 ]; then
         echo "Trino access and Hive S3 access tests passed."
         exit 0
       fi


### PR DESCRIPTION
Chainsaw executes scripts with /usr/bin/sh (dash on Ubuntu), which does not support [[ syntax.