### PR TITLE
fix(ci): add changed guard and ct setup to chart-e2e job

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -113,11 +113,35 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs deploy/helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run chart-e2e
+        if: steps.list-changed.outputs.changed == 'true'
         run: make chart-e2e


### PR DESCRIPTION
chart-e2e currently runs on every PR regardless of chart changes. Add ct list-changed guard, helm/ct installation steps, and if conditions to skip e2e when chart is unchanged.